### PR TITLE
Completely restructure meld mechanic and meld management

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
-from rummy import RummyGame, Card, Suit, Rank, RANK_NAMES
+from rummy import RummyGame, Card, Suit, Rank, MeldType, RANK_NAMES, MELD_TYPE_NAMES
 import uuid
 from typing import Dict, List, Optional
 import json
@@ -178,6 +178,12 @@ def start_game():
             "message": f"Error starting game: {str(e)}"
         }), 500
 
+def convert_card(card: Card) -> Dict:
+    return {"suit": card.suit.value, "value": RANK_NAMES[card.rank.value], "meld_type": MELD_TYPE_NAMES[card.meld_type.value]}
+
+def convert_card_back(data: Dict) -> Card:
+    return Card(suit=Suit(data["suit"]), rank=Rank(RANK_NAMES.index(data["value"])), meld_type=MeldType(MELD_TYPE_NAMES.index(data["meld_type"])))
+
 def get_game_for_player(game_id: str, player_id: str) -> Dict:
     """Helper function to get the game state for a specific player."""
     game = active_games[game_id]
@@ -185,10 +191,10 @@ def get_game_for_player(game_id: str, player_id: str) -> Dict:
         "gameID": game_id,
         "playerNames": game.player_names,
         "playerScores": [game.scores[i] for i in game.player_ids],
-        "hand": [{"suit": card.suit.value, "value": RANK_NAMES[card.rank.value]} for card in game.players_hands[player_id]],
+        "hand": [convert_card(card) for card in game.players_hands[player_id]],
         "handCts": [len(game.players_hands[i]) for i in game.player_ids],
-        "melds": [[[{"suit": card.suit.value, "value": RANK_NAMES[card.rank.value]} for card in meld.cards] for meld in p] for p in [game.players_melds[i] for i in game.player_ids]],
-        "discards": [{"suit": card.suit.value, "value": RANK_NAMES[card.rank.value]} for card in game.discard_pile],
+        "melds": [[[convert_card(card) for card in meld.cards] for meld in p] for p in [game.players_melds[i] for i in game.player_ids]],
+        "discards": [convert_card(card) for card in game.discard_pile],
         "stack": len(game.stack), 
         "activePlayerName": game.player_names[game.current_player], 
         "playerCount": game.num_players,
@@ -241,13 +247,13 @@ def game_move():
         if move == "draw-stack":
             game.draw_from_stack(player_id)
         elif move == "draw-discard":
-            card = Card(suit=Suit(data['data']['card']['suit']), rank=Rank(RANK_NAMES.index(data['data']['card']['value'])))
+            card = convert_card_back(data['data']['card'])
             game.draw_from_discard(player_id, card)
         elif move == "play-meld":
-            cards = [Card(suit=Suit(card['suit']), rank=Rank(RANK_NAMES.index(card['value']))) for card in data['data']['cards']]
+            cards = [convert_card_back(card) for card in data['data']['cards']]
             game.play_meld(player_id, cards)
         elif move == "discard":
-            card = Card(suit=Suit(data['data']['card']['suit']), rank=Rank(RANK_NAMES.index(data['data']['card']['value'])))
+            card = convert_card_back(data['data']['card'])
             game.discard_card(player_id, card)
         elif move == "sort":
             game.sort_hand(player_id)

--- a/backend/rummy.py
+++ b/backend/rummy.py
@@ -28,13 +28,20 @@ class Rank(Enum):
     QUEEN = 12
     KING = 13
 
+class MeldType(Enum):
+    NONE = 0
+    SET = 1
+    RUN = 2
+
 RANK_NAMES = ['','A','2','3','4','5','6','7','8','9','10','J','Q','K']
+MELD_TYPE_NAMES = ['NONE','SET','RUN']
 
 @dataclass
 class Card:
     """Represents a playing card."""
     suit: Suit
     rank: Rank
+    meld_type: MeldType
     
     def __str__(self) -> str:
         return f"{self.rank.name.lower()} of {self.suit.value}"
@@ -42,7 +49,7 @@ class Card:
     def __eq__(self, other) -> bool:
         if not isinstance(other, Card):
             return False
-        return self.suit == other.suit and self.rank == other.rank
+        return self.suit == other.suit and self.rank == other.rank and self.meld_type == other.meld_type
     
     def __hash__(self) -> int:
         return hash((self.suit, self.rank))
@@ -51,49 +58,26 @@ class Card:
 class Meld:
     """Represents a meld (set or run) of cards."""
     cards: List[Card]
-    meld_type: str  # "set" or "run"
-    built_on: Optional["Meld"] # can be None
+    meld_type: MeldType 
 
-def forms_solo_meld(cards: List[Card]) -> str:
+def forms_meld(cards: List[Card]) -> MeldType:
     if (len(cards) < 3):
-        return ""
+        return MeldType.NONE 
     
     rank = cards[0].rank 
-    if all(card.rank == rank for card in cards):
-        return "set"
+    if all(card.rank == rank and card.meld_type != MeldType.RUN for card in cards):
+        return MeldType.SET
     
     suit = cards[0].suit 
-    if not all(card.suit == suit for card in cards):
-        return ""
+    if not all(card.suit == suit and card.meld_type != MeldType.SET for card in cards):
+        return MeldType.NONE
     
     ranks = sorted([card.rank.value for card in cards])
     for i in range(1, len(ranks)):
         if (not ((ranks[i] == ranks[i - 1] + 1) or (i == 1 and ranks[0] == 1 and ranks[-1] == 13))):
-            return "" 
+            return MeldType.NONE
     
-    return "run"
-
-def forms_joint_meld(cards: List[Card], meld: Meld) -> bool:
-    c = cards + meld.cards 
-    p = meld.built_on
-    while (p is not None):
-        c += p.cards 
-        p = p.built_on
-    
-    if (meld.meld_type == "set"):
-        rank = c[0].rank 
-        return all(card.rank == rank for card in c)
-    
-    elif (meld.meld_type == "run"):
-        suit = c[0].suit 
-        if not all(card.suit == suit for card in c):
-            return False 
-        ranks = sorted([card.rank.value for card in cards])
-        for i in range(1, len(ranks)):
-            if (not (ranks[i] == ranks[i - 1] + 1) or (i == 1 and ranks[0] == 1 and ranks[-1] == 13)):
-                return False 
-        return True 
-    return False
+    return MeldType.RUN
 
 
 class RummyGame:
@@ -146,7 +130,7 @@ class RummyGame:
         self.stack = []
         for suit in Suit:
             for rank in Rank:
-                self.stack.append(Card(suit, rank))
+                self.stack.append(Card(suit, rank, MeldType.NONE))
         random.shuffle(self.stack)
     
     def _deal_cards(self) -> None:
@@ -260,42 +244,34 @@ class RummyGame:
         if player_id not in self.player_ids:
             raise ValueError(f"Invalid player ID: {player_id}")
         
-        # Check if player has all the cards
+        # Check if all cards are in player's hand or existing melds
         player_hand = self.players_hands[player_id]
+        existing_melds = [c for melds in self.players_melds.values() for m in melds for c in m.cards]
         for card in cards:
-            if card not in player_hand:
-                return False
+            if card.meld_type == MeldType.NONE:
+                if card not in player_hand:
+                    return False
+            else:
+                if card not in existing_melds:
+                    return False
         
-        meld = None 
-        if (len(cards) >= 3):
-            meld_type = forms_solo_meld(cards)
-            if meld_type:
-                meld = Meld(cards, meld_type, None)
-        else:
-            # Check if can form a run w/ any other sets
-            for p in self.players_melds.values():
-                for m in p:
-                    if m.meld_type == "run":
-                        if forms_joint_meld(cards, m):
-                            meld = Meld(cards, "run", m)
-            
-            for p in self.players_melds.values():
-                for m in p:
-                    if m.meld_type == "set":
-                        if forms_joint_meld(cards, m):
-                            meld = Meld(cards, "set", m)
-        
-        if meld is None:
+        # Check if cards form valid meld
+        meld_type = forms_meld(cards)
+        if meld_type == MeldType.NONE:
             self.event_log.append(f"{self.player_names[self.player_ids.index(player_id)]} attempted to play an invalid meld")
             return False
         
         # Remove cards from player's hand and add to player's melds
         cards.sort(key=lambda x: x.rank.value) # sort meld
+        meld = Meld([], meld_type)
         for card in cards:
-            player_hand.remove(card)
+            if card in player_hand:
+                player_hand.remove(card)
+                card.meld_type = meld_type
+                meld.cards.append(card)
         
         self.players_melds[player_id].append(meld)
-        self.event_log.append(f"{self.player_names[self.player_ids.index(player_id)]} played a {meld.meld_type}")
+        self.event_log.append(f"{self.player_names[self.player_ids.index(player_id)]} played a {MELD_TYPE_NAMES[meld.meld_type.value]}")
         # Check if player's hand is empty (game end condition)
         if len(player_hand) == 0:
             self.event_log.append(f"{self.player_names[self.player_ids.index(player_id)]} is out of cards!")

--- a/src/lib/game-container.svelte
+++ b/src/lib/game-container.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { RummyGame, Card, Suit, Value } from '$lib';
+    import { RummyGame, Card, Suit, Value, MeldType, formsMeld } from '$lib';
     import Playerbox from '$lib/playerbox.svelte';
     import CardBox from '$lib/cardbox.svelte';
     let { 
@@ -30,7 +30,7 @@
     // Check if it's the current player's turn
     let isMyTurn = $derived(currentGame.activePlayerName === playerName);
 
-    function handleCardClick(card: Card, location: 'discard' | 'stack' | 'hand', event: MouseEvent) {
+    function handleCardClick(card: Card, location: 'discard' | 'stack' | 'hand' | 'melds', event: MouseEvent) {
         if (!isMyTurn) return;
 
         if (location === 'discard') {
@@ -39,6 +39,9 @@
             drawFromStack();
         } else if (location === 'hand') {
             if (event.shiftKey) {
+				selectedCards = new Set();
+				discardCard(card);
+			} else {
                 // Toggle card selection
                 const newSelectedCards = new Set(selectedCards);
                 if (newSelectedCards.has(card)) {
@@ -47,11 +50,17 @@
                     newSelectedCards.add(card);
                 }
                 selectedCards = newSelectedCards;
-            } else {
-                // Discard the card
-                discardCard(card);
             }
-        }
+        } else if (location === 'melds') {
+			// Toggle card selection
+			const newSelectedCards = new Set(selectedCards);
+			if (newSelectedCards.has(card)) {
+				newSelectedCards.delete(card);
+			} else {
+				newSelectedCards.add(card);
+			}
+			selectedCards = newSelectedCards;
+		}
     }
 
     function handlePlayMeld() {
@@ -69,7 +78,6 @@
 
 	$effect(() => {
 		if (currentGame.eventLog.length > 0) {
-			console.log("This line runs");
 			scrollContainer.scrollTop = scrollContainer.scrollHeight;
 		}
 	})
@@ -80,10 +88,10 @@
 <div class="game-container">
 	<main class="game-main">
         {#if currentGame.playerCount > 2}
-        <Playerbox game={currentGame} playerIndex={leftPlayerIndex} vertical={true} lefttop={true} user={false}/> 
+        <Playerbox game={currentGame} playerIndex={leftPlayerIndex} vertical={true} lefttop={true} user={false} handleCardClick={handleCardClick} isCardSelected={isCardSelected} isMyTurn={isMyTurn}/> 
         {/if}
         <div class="center-area">
-            <Playerbox game={currentGame} playerIndex={oppoPlayerIndex} vertical={false} lefttop={true} user={false}/>
+            <Playerbox game={currentGame} playerIndex={oppoPlayerIndex} vertical={false} lefttop={true} user={false} handleCardClick={handleCardClick} isCardSelected={isCardSelected} isMyTurn={isMyTurn}/>
             <!-- Discard pile -->
 			<div class="discards-section">
 				<h3>Discard Pile</h3>
@@ -92,11 +100,11 @@
                     <button 
                         class="clickable-card" 
                         class:disabled={!isMyTurn}
-                        onclick={(e) => handleCardClick(new Card(Suit.SPADES, Value.ACE), 'stack', e)}
+                        onclick={(e) => handleCardClick(new Card(Suit.SPADES, Value.ACE, MeldType.NONE), 'stack', e)}
                         type="button"
                         disabled={!isMyTurn}
                     >
-                        <CardBox card={new Card(Suit.SPADES, Value.ACE)} revealed={false}/>
+                        <CardBox card={new Card(Suit.SPADES, Value.ACE, MeldType.NONE)} revealed={false}/>
                     </button>
                     {/if}
 					{#each currentGame.discards as card}
@@ -130,7 +138,8 @@
                     <button 
                         class="play-meld-button" 
                         onclick={handlePlayMeld}
-                        disabled={selectedCards.size === 0}
+                        disabled={!formsMeld(selectedCards)}
+						hidden={selectedCards.size === 0}
                         type="button"
                     >
                         Play Meld ({selectedCards.size} cards)
@@ -139,7 +148,7 @@
             {/if}
         </div>
         {#if currentGame.playerCount > 3}
-        <Playerbox game={currentGame} playerIndex={rightPlayerIndex} vertical={true} lefttop={true} user={false}/> 
+        <Playerbox game={currentGame} playerIndex={rightPlayerIndex} vertical={true} lefttop={true} user={false} handleCardClick={handleCardClick} isCardSelected={isCardSelected} isMyTurn={isMyTurn}/> 
         {/if}
 	</main>
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -24,15 +24,88 @@ export enum Value {
     KING = 'K'
 }
 
+export enum MeldType {
+    NONE = 'NONE',
+    SET = 'SET',
+    RUN = 'RUN'
+}
+
 // Card class
 export class Card {
     suit: Suit;
     value: Value;
+    meld_type: MeldType;
 
-    constructor(suit: Suit, value: Value) {
+    constructor(suit: Suit, value: Value, meld_type: MeldType) {
         this.suit = suit;
         this.value = value;
+        this.meld_type = meld_type;
     }
+}
+
+// Function to see if a meld is formed
+export function formsMeld(cards: Set<Card>): boolean {
+    const list = Array.from(cards);
+
+    if (list.length < 3) {
+        return false;
+    }
+
+    // ----- Check for SET -----
+    const firstRank = list[0].value;
+    const isSet = list.every(
+        card => card.value === firstRank && card.meld_type !== MeldType.RUN
+    );
+
+    if (isSet) {
+        return true;
+    }
+
+    // ----- Check for RUN -----
+    const firstSuit = list[0].suit;
+    const sameSuit = list.every(
+        card => card.suit === firstSuit && card.meld_type !== MeldType.SET
+    );
+
+    if (!sameSuit) {
+        return false;
+    }
+
+    // Sort ranks
+    const valueMenu = new Map<Value, number>();
+    valueMenu.set(Value.ACE, 1);
+    valueMenu.set(Value.TWO, 2);
+    valueMenu.set(Value.THREE, 3);
+    valueMenu.set(Value.FOUR, 4);
+    valueMenu.set(Value.FIVE, 5);
+    valueMenu.set(Value.SIX, 6);
+    valueMenu.set(Value.SEVEN, 7);
+    valueMenu.set(Value.EIGHT, 8);
+    valueMenu.set(Value.NINE, 9);
+    valueMenu.set(Value.TEN, 10);
+    valueMenu.set(Value.JACK, 11);
+    valueMenu.set(Value.QUEEN, 12);
+    valueMenu.set(Value.KING, 13);
+
+    const ranks = list
+        .map(card => card.value)
+        .map(x => valueMenu.get(x)!)
+        .sort((a, b) => a - b);
+
+    // Check consecutive ranks, including Ace–King wrap
+    for (let i = 1; i < ranks.length; i++) {
+        const prev = ranks[i - 1];
+        const curr = ranks[i];
+
+        const normalStep = curr === prev + 1;
+        const aceWrap = i === 1 && ranks[0] === 1 && ranks[ranks.length - 1] === 13;
+
+        if (!normalStep && !aceWrap) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 // RummyGame class

--- a/src/lib/playerbox.svelte
+++ b/src/lib/playerbox.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { RummyGame, Card, Suit, Value } from '$lib';
+	import { RummyGame, Card, Suit, Value, MeldType } from '$lib';
 	import CardBox from '$lib/cardbox.svelte';
 
     let { 
@@ -18,7 +18,7 @@
         vertical: boolean, 
         lefttop: boolean, 
         user: boolean,
-        handleCardClick?: (card: Card, location: 'discard' | 'stack' | 'hand', event: MouseEvent) => void,
+        handleCardClick?: (card: Card, location: 'discard' | 'stack' | 'hand' | 'melds', event: MouseEvent) => void,
         isCardSelected?: (card: Card) => boolean,
 		sortHand?: () => void,
         isMyTurn?: boolean
@@ -61,7 +61,24 @@
 			{#each playerMelds as meld}
             <div class="meld">
 				{#each meld as card}
-					<CardBox card={card} revealed={true} />
+					{#if handleCardClick && isMyTurn}
+						<button 
+							class="hand-card" 
+							class:selected={isCardSelected && isCardSelected(card)}
+							class:clickable={true}
+							onclick={(e) => handleCardClick(card, 'melds', e)}
+							type="button"
+						>
+							<CardBox card={card} revealed={true} />
+						</button>
+					{:else}
+						<div 
+							class="hand-card" 
+							class:selected={isCardSelected && isCardSelected(card)}
+						>
+							<CardBox card={card} revealed={true} />
+						</div>
+					{/if}
 				{/each}
             </div>
 			{/each}
@@ -101,7 +118,7 @@
 			{:else}
 				<!-- Show hidden cards for other players -->
 				{#each Array(handCount) as _, i}
-					<CardBox card={new Card(Suit.SPADES, Value.ACE)} revealed={false} />
+					<CardBox card={new Card(Suit.SPADES, Value.ACE, MeldType.NONE)} revealed={false} />
 				{/each}
 			{/if}
 		</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,7 +22,7 @@
 	$effect(() => console.log(currentGame));
 
 	function convertCardData(cardData: any): Card {
-		return new Card(cardData.suit, cardData.value
+		return new Card(cardData.suit, cardData.value, cardData.meld_type
 		);
 	}
 
@@ -117,7 +117,7 @@
 		await makeGameMove('discard', { card: card });
 	}
 
-	async function sortHand(card: any) {
+	async function sortHand() {
 		await makeGameMove('sort', {});
 	}
 


### PR DESCRIPTION
Resolves #1 by re-setting the selectedCard set upon discard.
Resolves #6 by using new, simpler meld identification logic.
Resolves #8 by switching to shift-click to discard.  No matter that I'm used to using shift-click for melds and keep discarding on accident when I have a meld now.
Resolves #10 by requiring the cards off which a meld is played to be selected.
Resolves #11 using front-end implementation of the same simpler meld identification logic.